### PR TITLE
Closes #4574 link button fix

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -77,28 +77,30 @@
 
         {#if user.isAdmin}
           <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_USER_MANAGEMENT}>
-            <div class="hidden sm:block">
-                <span
+            <div class="inline-flex items-center justify-center transition-colors dark:text-immich-dark-fg p-2 font-medium rounded-lg">
+              <div class="hidden sm:block">
+                  <span
+                    class={$page.url.pathname.includes('/admin')
+                      ? 'item text-immich-primary underline dark:text-immich-dark-primary'
+                      : ''}
+                  >
+                    Administration
+                  </span>
+              </div>
+              <div class="block sm:hidden">
+                  <Cog
+                    size="1.5em"
+                    class="dark:text-immich-dark-fg {$page.url.pathname.includes('/admin')
+                      ? 'text-immich-primary dark:text-immich-dark-primary'
+                      : ''}"
+                  />
+                <hr
                   class={$page.url.pathname.includes('/admin')
-                    ? 'item text-immich-primary underline dark:text-immich-dark-primary'
-                    : ''}
-                >
-                  Administration
-                </span>
-            </div>
-            <div class="block sm:hidden">
-                <Cog
-                  size="1.5em"
-                  class="dark:text-immich-dark-fg {$page.url.pathname.includes('/admin')
-                    ? 'text-immich-primary dark:text-immich-dark-primary'
-                    : ''}"
+                    ? 'border-1 mx-auto block w-2/3 border-immich-primary dark:border-immich-dark-primary'
+                    : 'hidden'}
                 />
-              <hr
-                class={$page.url.pathname.includes('/admin')
-                  ? 'border-1 mx-auto block w-2/3 border-immich-primary dark:border-immich-dark-primary'
-                  : 'hidden'}
-              />
-            </div>
+              </div>
+           </div>
           </a>
         {/if}
 

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -78,7 +78,6 @@
         {#if user.isAdmin}
           <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_USER_MANAGEMENT}>
             <div class="hidden sm:block">
-              <LinkButton>
                 <span
                   class={$page.url.pathname.includes('/admin')
                     ? 'item text-immich-primary underline dark:text-immich-dark-primary'
@@ -86,17 +85,14 @@
                 >
                   Administration
                 </span>
-              </LinkButton>
             </div>
             <div class="block sm:hidden">
-              <IconButton title="Administration">
                 <Cog
                   size="1.5em"
                   class="dark:text-immich-dark-fg {$page.url.pathname.includes('/admin')
                     ? 'text-immich-primary dark:text-immich-dark-primary'
                     : ''}"
                 />
-              </IconButton>
               <hr
                 class={$page.url.pathname.includes('/admin')
                   ? 'border-1 mx-auto block w-2/3 border-immich-primary dark:border-immich-dark-primary'

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -95,6 +95,7 @@
                       : ''}"
                   />
                 <hr
+                  role="decoration"
                   class={$page.url.pathname.includes('/admin')
                     ? 'border-1 mx-auto block w-2/3 border-immich-primary dark:border-immich-dark-primary'
                     : 'hidden'}

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -76,7 +76,12 @@
         {/if}
 
         {#if user.isAdmin}
-          <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_USER_MANAGEMENT}>
+          <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_USER_MANAGEMENT}
+            aria-current={$page.url.pathname.includes('/admin')
+            ? 'page'
+            : null
+            }
+            >
             <div class="inline-flex items-center justify-center transition-colors dark:text-immich-dark-fg p-2 font-medium rounded-lg">
               <div class="hidden sm:block">
                   <span


### PR DESCRIPTION
This PR fixes some semantic issues important for accessibility;

1. no more `button` inside `a`.
2. horizontal rule isn't the best option to indicate current page, so `role="presentation"` added to it.
3. instead of horizontal rule semantics we can use `aria-current="page"` on the link to express state to screen-readers.
